### PR TITLE
Nar/small improvements

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -57,6 +57,7 @@ link_verbose_0 = @echo " LD    " $(@F);
 link_verbose = $(link_verbose_$(V))
 
 SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+HEADERS := $(shell find $(C_SRC_DIR) -type f \( -name "*.h" -o -name "*.H" -o -name "*.hh" -o -name "*.hpp" \))
 OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
 
 COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
@@ -66,16 +67,16 @@ $(C_SRC_OUTPUT): $(OBJECTS)
 	@mkdir -p $(BASEDIR)/priv/
 	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) $(LDLIBS) -o $(C_SRC_OUTPUT)
 
-%.o: %.c
+%.o: %.c $(HEADERS)
 	$(COMPILE_C) $(OUTPUT_OPTION) $<
 
-%.o: %.cc
+%.o: %.cc $(HEADERS)
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
-%.o: %.C
+%.o: %.C $(HEADERS)
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
-%.o: %.cpp
+%.o: %.cpp $(HEADERS)
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
 clean:

--- a/src/fix.erl
+++ b/src/fix.erl
@@ -80,7 +80,7 @@ start_exec_conn(Name) ->
 %% @doc fix local reimplementation of UTC as a string 
 -spec now() -> string().
 now() ->
-  timestamp(to_date_ms(erlang:timestamp())).
+  timestamp(to_date_ms(os:timestamp())).
 
 -spec timestamp({calendar:date(), {0..23, 0..59, 0..59, non_neg_integer()}}) -> string().
 timestamp({{YY,MM,DD},{H,M,S,Milli}}) ->

--- a/src/fix_read_conn.erl
+++ b/src/fix_read_conn.erl
@@ -162,6 +162,10 @@ when Closed == tcp_closed; Closed == ssl_closed ->
   ?D({fix_connection,socket_closed, Host, Port}),
   {stop, socket_closed, Conn};
 
+handle_info({tcp_error, Socket, Reason}, #conn{socket = Socket, host = Host, port = Port} = Conn) ->
+  ?D({fix_connection,socket_error, Host, Port, Reason}),
+  {stop, socket_closed, Conn};
+
 % We monitor only stocks, so try to unsubscribe
 handle_info({'DOWN', _, _, {Stock, _}, _}, #conn{} = Conn) when is_atom(Stock) ->
   case unsubscribe_stock(Stock, Conn) of

--- a/src/fix_read_manager.erl
+++ b/src/fix_read_manager.erl
@@ -3,7 +3,6 @@
 
 -include("log.hrl").
 -include("../include/fix.hrl").
--include("../include/business.hrl").
 
 % Public API
 -export([start_link/1, new_stock/2]).


### PR DESCRIPTION
Some small improvements:

- Handle `tcp_error` more gracefully, instead of crashing the `fix_read_conn` server, just stop it.
- Make sure the NIF library is rebuilt when the header file is changed.
- Get the current date and time from the operating system - when the computer is hibernated, then waken up, `erlang:timestamp/0` might return wrong (too old) date.
- Removed a not used include.