### PR TITLE
Fixed name of SecurityRequestResult field in SecurityList message.

### DIFF
--- a/include/business.hrl
+++ b/include/business.hrl
@@ -251,7 +251,7 @@
 
 -record(security_list, {
   security_req_id,
-  subscription_request_result,
+  security_request_result,
   symbols = [],
   fields = []
 }).

--- a/test/fix_tests.erl
+++ b/test/fix_tests.erl
@@ -207,7 +207,7 @@ security_list_decoding_test() ->
     {ok, DecodedSL, _, <<>>} = fix:decode_printable(SecurityList),
     ?assertMatch(#security_list{
                     security_req_id= <<"SLR_01631014961437">>,
-                    subscription_request_result = 0,
+                    security_request_result = 0,
                     symbols = _,
                     fields = _
                    }, DecodedSL).


### PR DESCRIPTION
There was a typo in the field name in the record.