### PR TITLE
Fixed NIFs on Apple M1.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -21,9 +21,9 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/fix_splitter.so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
The new Apple processor is not x86_64 based, so do not specify this
architecture when compiling for Darwin.